### PR TITLE
#167271884 Add delete property advert flag end point

### DIFF
--- a/src/controllers/properties/index.js
+++ b/src/controllers/properties/index.js
@@ -328,6 +328,17 @@ class Properties {
     });
     return reply.send(res);
   }
+
+  static deletePropertyFlag(req, res) {
+    const { data } = req;
+    const propertyFlag = data.get('PropertyFlag');
+    const propertyFlagsDb = this.getFlagsDb(req);
+
+    propertyFlagsDb.delete(propertyFlag.get('id'));
+    return Reply('Property flag removed succesfully')
+      .setStatusCode(204)
+      .send(res);
+  }
 }
 
 export const {
@@ -343,5 +354,6 @@ export const {
   getPropertyFlag,
   flagProperty,
   updatePropertyFlag,
+  deletePropertyFlag,
 } = Properties;
 export default Properties;

--- a/src/routes/property/flag/index.js
+++ b/src/routes/property/flag/index.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { enforceLogged } from '../../../middlewares/auth/index';
 import { processProperty } from '../../../middlewares/property/index';
 import { ensureUserHasPermission, processPropertyFlag } from '../../../middlewares/property/flag/index';
-import { flagProperty, updatePropertyFlag } from '../../../controllers/properties/index';
+import { flagProperty, updatePropertyFlag, deletePropertyFlag } from '../../../controllers/properties/index';
 
 const router = Router({
   mergeParams: true,
@@ -18,6 +18,15 @@ router.route('/:propertyFlagId')
       ensureUserHasPermission,
     ],
     updatePropertyFlag,
+  )
+  .delete(
+    [
+      processProperty,
+      processPropertyFlag,
+      enforceLogged,
+      ensureUserHasPermission,
+    ],
+    deletePropertyFlag,
   );
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?

Have delete property advert flag end point functional

#### Description of Task to be completed?

Have the following working

1) Validate user permission
2) remove property advert flag or respond with appropriate error messages and status codes

#### How should this be manually tested?

1) Clone the repository, and then run npm run test or 
2) use post man and send a delete request to this end point _/property/:property-id/flag/:flag-id_
 
#### Any background context you want to provide?

1) Javascript Map was used as the model to save users data

#### What are the relevant pivotal tracker stories?

#167271884